### PR TITLE
Исправлен баг, когда в комментарий вставлена картинка большой ширины

### DIFF
--- a/app/stylesheets/less/blocks/comments.less
+++ b/app/stylesheets/less/blocks/comments.less
@@ -97,6 +97,14 @@
   font-weight: bold;
 }
 
+.comment__text {
+  img {
+    max-width: 100%;
+    margin: 8px 0;
+    display: block;
+  }
+}
+
 .comment__meta {
   height: 18px;
   position: absolute;


### PR DESCRIPTION
Текст комментария нужно оборачивать в span.comment__text, иначе не подхватятся стили.
